### PR TITLE
Fix simple, hasMany=false relationship with string as relationTo not working

### DIFF
--- a/demo/src/hooks/backpopulate.hook.ts
+++ b/demo/src/hooks/backpopulate.hook.ts
@@ -19,6 +19,13 @@ export const backpopulateAfterChangeHookFactory = ({
 
       //If the relationTo "value" is an array with length 1: Usually: Value [ '6307772a5aa9f04ab75df7d4' ] with this: [ { relationTo: 'gear-component', value: '6307772a5aa9f04ab75df7d4' } ]
 
+      if (!Array.isArray(value)) {
+          value = [value];
+      }
+      if (!Array.isArray(previousValue)) {
+          previousValue = [previousValue];
+      }
+      
       const removedTargetIds = previousValue
         ? [...previousValue].filter((x) => !value.includes(x))
         : [];


### PR DESCRIPTION
Without this, simple hasMany=false relationships defined like this:
```ts
{
            name: 'a_fingerprinted_users',
            type: 'relationship',
            relationTo: 'a_fingerprinted_users',
            hasMany: false,
            hooks: {
                afterChange: [backpopulate],
            }
}
```

break due to the filter function not working